### PR TITLE
Helm: Replace deployment with statefulset

### DIFF
--- a/helm-charts/concordium-node/README.md
+++ b/helm-charts/concordium-node/README.md
@@ -1,17 +1,19 @@
 # Helm chart: concordium-node
 
-A very basic chart for deploying a node with a collector in a Kubernetes cluster.
-The two applications run in different containers in the same pod using a `deployment` and a `service`.
-An init container copies the genesis data file on startup into an ephemeral volume belonging to the pod.
+A basic chart for deploying a node with a collector in a Kubernetes cluster.
+The two applications run in different containers within the same pod using a `statefulset` and a `service`.
+An init container copies the genesis data file on startup into a persistent volume belonging to the pod.
 
 No `ingress` is being set up because the endpoints are not HTTP based.
+
+The chart has been verified to work (with 1 and 2 replicas) in [minikube](https://minikube.sigs.k8s.io/docs/) on Linux.
 
 *Missing features*
 
 - There is no mechanism for injecting baker credentials.
-- No persistent storage is being set up atm.
-- Given that the node is stateful (once persistent storage is added),
-  a `statefulset` would probably be a better match than a `deployment`.
+- Multiple replicas are not well-supported:
+  It works but there is no mechanism for configuring them differently
+  (e.g., different node names).
 - The chart contains no tests.
 
 ## Install

--- a/helm-charts/concordium-node/templates/statefulset.yaml
+++ b/helm-charts/concordium-node/templates/statefulset.yaml
@@ -1,9 +1,10 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "fullname" . }}
   labels: {{ include "labels" . | fromYaml | toJson }}
 spec:
+  serviceName: {{ include "fullname" . }}
   replicas: 1
   selector:
     matchLabels: {{ include "selectorLabels" . | fromYaml | toJson }}
@@ -17,14 +18,16 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets: {{ toJson . }}
       {{- end }}
-      securityContext: {{ toJson .Values.podSecurityContext }}
+      {{- with .Values.podSecurityContext }}
+      securityContext: {{ toJson . }}
+      {{- end }}
       containers:
       - name: node
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         command:
         - /concordium-node
         - --data-dir=/mnt/data
-        - --config-dir=/mnt/config
+        - --config-dir=/mnt/data
         - --bootstrap-node=bootstrap.mainnet.concordium.software:8888
         - --rpc-server-addr=0.0.0.0
         - --prometheus-server
@@ -37,11 +40,13 @@ spec:
           containerPort: 10000
         - name: metrics
           containerPort: 9090
-        resources: {{ toJson .Values.resources }}
-        securityContext: {{ toJson .Values.securityContext }}
+        {{- with .Values.resources }}
+        resources: {{ toJson . }}
+        {{- end }}
+        {{- with .Values.securityContext }}
+        securityContext: {{ toJson . }}
+        {{- end }}
         volumeMounts:
-        - name: config
-          mountPath: /mnt/config
         - name: data
           mountPath: /mnt/data
       {{- if .Values.nodeName }}
@@ -62,6 +67,10 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /mnt/data
+      enableServiceLinks: false
+      {{- with .Values.restartPolicy }}
+      restartPolicy: {{ . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector: {{ toJson . }}
       {{- end }}
@@ -71,10 +80,13 @@ spec:
       {{- with .Values.tolerations }}
       tolerations: {{ toJson . }}
       {{- end }}
-      volumes:
-      - name: config
-        emptyDir: {}
-      # TODO use proper storage and add a secret with any baker credentials
-      #      (could also contain 'genesis.dat' which would eliminate the need for the init container)
-      - name: data
-        emptyDir: {}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: {{ default "standard" .Values.storage.className }}
+      resources:
+        requests:
+          storage: {{ .Values.storage.size }}

--- a/helm-charts/concordium-node/values.yaml
+++ b/helm-charts/concordium-node/values.yaml
@@ -22,10 +22,16 @@ service:
     metrics: 9090
     rpc: 10000
 
+# storage configures the class and size of the persistent volume that the database is stored on.
+storage:
+  className: standard
+  size: 10Gi
+
 # The fields below are kept from the scaffolding initialized by Helm to do detailed configuration of the deployment.
-# See their use in 'templates/deployment.yaml' and lookup the docs of the relevant fields in the official API docs
+# See their use in 'templates/statefulset.yaml' and lookup the docs of the relevant fields in the official API docs
 # (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/).
 
+restartPolicy: Always
 podAnnotations: {}
 podSecurityContext: {}
 securityContext: {}


### PR DESCRIPTION
Given that the node is stateful (as this PR also configures persistent storage), a `statefulset` is a better fit than `deployment`: It introduces the notion of [pod identity](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-identity) (unique pod name, hostname, and storage), which makes it possible for distinct replicas to be configured differently.

The templates don't yet make use of this ability; this conversion is only a step in that direction.