### PR TITLE
CI: Set up pre-commit hook for yamllint

### DIFF
--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -11,6 +11,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Install 'yamllint'
-      run: pip install --user yamllint==1.26.1
+      run: pip install --user yamllint==1.26.3
     - name: Run 'yamllint'
       run: yamllint --strict --format=github .

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 !.*ignore
 !.*lint
 !.github
+!.pre-commit-config.yaml
 env/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+- repo: local
+  hooks:
+  - id: yamllint
+    name: yamllint
+    entry: yamllint --strict .
+    pass_filenames: false
+    language: system

--- a/.yamllint
+++ b/.yamllint
@@ -2,10 +2,12 @@ extends: default
 
 ignore: |
   helm-charts/*/templates
+  env/
 
 rules:
   comments:
     min-spaces-from-content: 1
+  comments-indentation: disable
   document-end:
     present: false
   document-start:

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ See [`docker-compose.yaml`](./docker-compose.yaml) for a working run configurati
 ## Build and/or run using Docker Compose
 
 The setup relies on features that are only available in relatively recent versions of Docker Compose.
-The `requrements.txt` file specifies a compatible version (the latest v1 release at the time of this writing)
+The `requirements.txt` file specifies a compatible version (the latest v1 release at the time of this writing)
 which may be installed (preferably in a [virtualenv](https://docs.python.org/3/library/venv.html))
 using `pip install -r requirements.txt`.
 
@@ -236,6 +236,6 @@ The hook is implemented using the [`pre-commit`](https://pre-commit.com/) tool w
 pip install pre-commit
 ```
 
-The `requrements.txt` file specifies a compatible version.
+The `requirements.txt` file specifies a compatible version.
 
 Then just run `pre-commit install` from the project root to install the hook that's defined in `.pre-commit-config.yaml`.

--- a/README.md
+++ b/README.md
@@ -223,3 +223,19 @@ use your own copy/fork or just take the files that you need.
 By using any files from this repository,
 you accept full responsibility of their effect and availability now and in the future,
 so review carefully and only apply changes explicitly.
+
+## Development
+
+### Git pre-commit hook
+
+To avoid committing incorrectly formatted YAML (and have it rejected by the CI), a git pre-commit hook can verify it before committing:
+
+The hook is implemented using the [`pre-commit`](https://pre-commit.com/) tool which may be installed using `pip`:
+
+```
+pip install pre-commit
+```
+
+The `requrements.txt` file specifies a compatible version.
+
+Then just run `pre-commit install` from the project root to install the hook that's defined in `.pre-commit-config.yaml`.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -69,7 +69,8 @@ services:
     - node
     networks:
     - concordium
-    restart: unless-stopped  # service may time out before the node is operational (shouldn't use 'on-failure' becuase that will cause the container to start on boot)
+    restart: unless-stopped  # service may time out before the node is operational
+                             # (shouldn't use 'on-failure' as that will make the container auto start on boot)
     stop_signal: SIGKILL     # application doesn't react to SIGINT nor SIGTERM
   node-dashboard-grpc-proxy:
     image: envoyproxy/envoy:v1.18-latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 docker-compose==1.29.2
+pre-commit==2.17.0


### PR DESCRIPTION
Add configuraion and documentation for setting up local pre-commit hook to run yamllint before committing changes.

Includes bump of yamllint from v1.26.1 to v1.26.3 and fix of existing linting error.