### PR TITLE
Compose: Add ability to re-fetch OOB data

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     pull_policy: always
     user: root
     environment:
-    - OOB_CATCHUP_REFRESH_AGE_SECS=${OOB_CATCHUP_REFRESH_AGE_SECS-1209600} # default: 14d
+    - OOB_CATCHUP_REFRESH_AGE_SECS
     volumes:
     - data:/mnt/data
     entrypoint:
@@ -18,8 +18,8 @@ services:
       now_ts="$$(date +%s)"
       age_secs="$$((now_ts - last_ts))"
 
-      # Fetch blocks unless age is less than configured limit.
-      [ "$${age_secs}" -lt "$${OOB_CATCHUP_REFRESH_AGE_SECS}" ] ||
+      # Fetch blocks unless age is less than configured limit which defaults to "now" (i.e. never).
+      [ "$${age_secs}" -lt "$${OOB_CATCHUP_REFRESH_AGE_SECS-$${now_ts}}" ] ||
         curl -sSf https://catchup.${DOMAIN}/blocks_to_import.mdb -o /mnt/data/blocks.mdb
   node:
     image: ${NODE_IMAGE}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,13 +4,22 @@ services:
     image: curlimages/curl:latest
     pull_policy: always
     user: root
+    environment:
+    - OOB_CATCHUP_REFRESH_AGE_SECS=${OOB_CATCHUP_REFRESH_AGE_SECS-1209600} # default: 14d
     volumes:
     - data:/mnt/data
     entrypoint:
     - /bin/sh
-    - -c
+    - -xc
     - |
-      [ -f /mnt/data/blocks.mdb ] ||
+      # Compute number of seconds since last modification of '/mnt/data/lock.mdb'.
+      # If the file doesn't exist, the "age" defaults to the current Unix time.
+      last_ts="$$(stat -c %Y /mnt/data/lock.mdb 2>/dev/null || echo 0)"
+      now_ts="$$(date +%s)"
+      age_secs="$$((now_ts - last_ts))"
+
+      # Fetch blocks unless age is less than configured limit.
+      [ "$${age_secs}" -lt "$${OOB_CATCHUP_REFRESH_AGE_SECS}" ] ||
         curl -sSf https://catchup.${DOMAIN}/blocks_to_import.mdb -o /mnt/data/blocks.mdb
   node:
     image: ${NODE_IMAGE}

--- a/mainnet.env
+++ b/mainnet.env
@@ -2,5 +2,6 @@ COMPOSE_PROJECT_NAME=mainnet
 COMPOSE_PROFILES=node-dashboard
 DOMAIN=mainnet.concordium.software
 GENESIS_DATA_FILE=./genesis/mainnet-0.dat
+OOB_CATCHUP_REFRESH_AGE_SECS=1209600 # 14d
 NODE_IMAGE=bisgardo/concordium-node:3.0.1-2_1
 NODE_DASHBOARD_IMAGE=bisgardo/concordium-node-dashboard:node-3.0.1-2_1

--- a/testnet.env
+++ b/testnet.env
@@ -2,5 +2,6 @@ COMPOSE_PROJECT_NAME=testnet
 COMPOSE_PROFILES=node-dashboard
 DOMAIN=testnet.concordium.com
 GENESIS_DATA_FILE=./genesis/testnet-0.dat
+OOB_CATCHUP_REFRESH_AGE_SECS=1209600 # 14d
 NODE_IMAGE=bisgardo/concordium-node:3.0.1-2_1
 NODE_DASHBOARD_IMAGE=bisgardo/concordium-node-dashboard:node-3.0.1-2_1


### PR DESCRIPTION
The value of the environment variable `OOB_CATCHUP_REFRESH_AGE_SECS` is compared against the modification time of `lock.mdb`. If it's older, a re-fetch is triggered. The refresh age defaults to never, but is set to 14 days in the env files.

The node actually does reengage OOB catchup with the updated file, though it isn't clear what (if any) performance benefit it has compared to standard catchup: In the test it took about 10 mins before it started processing blocks, and afterwards did fully catch up within a reasonable amount of time. The delay is probably caused by the whole file having to be processed.

To determine the optimal refresh age value, benchmarks would have to be set up.

Resolves #9.