### PR TITLE
K8s: Improve and upgrade Helm chart

### DIFF
--- a/helm-charts/concordium-node/Chart.yaml
+++ b/helm-charts/concordium-node/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: concordium-node
-description: "Deployment of a concordium-node instance with a collector and genesis injection."
+description: "Deployment of a concordium-node instance with an optional collector companion."
 type: application
-version: 0.1.0
-appVersion: 1.0.0
+version: "0.2.0"
+appVersion: "3.0.2"

--- a/helm-charts/concordium-node/README.md
+++ b/helm-charts/concordium-node/README.md
@@ -16,15 +16,43 @@ The chart has been verified to work (with 1 and 2 replicas) in [minikube](https:
   (e.g., different node names).
 - The chart contains no tests.
 
-## Install
+## Prerequisites
+
+Some of the following will have to be set up for the chart to start running successfully.
+It's not important to do any of it before installing the chart
+as Kubernetes will just wait for the relevant resources to be present.
+
+The node depends on a configmap holding the genesis data file. Install using the following command, executed from the project root:
 
 ```shell
-helm install concordium-node . --set nodeName=<name>
+kubectl create configmap genesis --from-file=testnet=./genesis/testnet-0.dat --from-file=mainnet=./genesis/mainnet-0.dat
+```
+
+If running with a "lesser managed" Kubernetes cluster, the persistent volume might need to be created manually.
+The example PV spec in `local-persistentvolume.yaml` may be setup using
+
+```shell
+kubectl apply -f ./local-persistentvolume.yaml
+```
+
+In the case of Minikube, there is an addon `storage-provisioner` that enables automatic provisioning. Enable using
+
+```shell
+minikube addons enable storage-provisioner
+```
+
+## Install
+
+Install or upgrade the chart using the command:
+
+```shell
+helm upgrade --install concordium-node . --set=nodeName=<name> --set=network=<network>
 ```
 
 where `<name>` is the name of the node to be presented on the
 [public dashboard](https://dashboard.mainnet.concordium.software/)
-(set to empty to disable the collector container).
+(set to empty to disable the collector container)
+and `<network>` is `testnet` or `mainnet`.
 
 Also consider overriding the image repositories (using `--set` or a custom values file).
 See [values.yaml](./values.yaml) (e.g. using `helm show values .`)

--- a/helm-charts/concordium-node/local-persistentvolume.yaml
+++ b/helm-charts/concordium-node/local-persistentvolume.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: concordium-node
+  labels:
+    type: local
+spec:
+  storageClassName: standard
+  capacity:
+    storage: 100Gi
+  accessModes:
+  - ReadWriteOnce
+  hostPath:
+    path: "/mnt/data"

--- a/helm-charts/concordium-node/templates/_helpers.tpl
+++ b/helm-charts/concordium-node/templates/_helpers.tpl
@@ -1,13 +1,13 @@
 {{/*
-Expand the name of the chart.
+Expanded name of the chart.
 */}}
 {{- define "name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+Default fully qualified app name.
+Truncated at 63 chars as some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "fullname" -}}
@@ -24,14 +24,14 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
-Create chart name and version as used by the chart label.
+Chart name and version as used by the chart label.
 */}}
 {{- define "chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
-Common labels
+Common labels.
 */}}
 {{- define "labels" -}}
 helm.sh/chart: {{ include "chart" . }}
@@ -43,9 +43,24 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
-Selector labels
+Selector labels.
 */}}
 {{- define "selectorLabels" -}}
 app.kubernetes.io/name: {{ include "name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Domain name of the network.
+May be specified literally with the value field 'domain'
+or inferred as an official Concordium network using 'network'.
+For network "mainnet", the domain is "mainnet.concordium.software".
+Otherwise it resolves to "<network>.concordium.com".
+*/}}
+{{- define "domain" -}}
+{{- if .Values.domain }}
+{{- .Values.domain | quote }}
+{{- else }}
+{{- .Values.network }}.concordium.{{ if eq .Values.network "mainnet" }}software{{ else }}com{{ end }}
+{{- end }}
 {{- end }}

--- a/helm-charts/concordium-node/templates/statefulset.yaml
+++ b/helm-charts/concordium-node/templates/statefulset.yaml
@@ -24,15 +24,24 @@ spec:
       containers:
       - name: node
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        command:
-        - /concordium-node
-        - --data-dir=/mnt/data
-        - --config-dir=/mnt/data
-        - --bootstrap-node=bootstrap.mainnet.concordium.software:8888
-        - --rpc-server-addr=0.0.0.0
-        - --prometheus-server
-        - --prometheus-listen-addr=0.0.0.0
-        - --no-dnssec
+        command: [ /concordium-node ]
+        env:
+        - name: CONCORDIUM_NODE_DATA_DIR
+          value: /mnt/data
+        - name: CONCORDIUM_NODE_CONFIG_DIR
+          value: /mnt/data
+        - name: CONCORDIUM_NODE_CONSENSUS_IMPORT_BLOCKS_FROM
+          value: /mnt/data/blocks.mdb
+        - name: CONCORDIUM_NODE_CONSENSUS_GENESIS_DATA_FILE
+          value: /mnt/genesis/genesis.dat
+        - name: CONCORDIUM_NODE_CONNECTION_BOOTSTRAP_NODES
+          value: "bootstrap.{{ include "domain" . }}:8888"
+        - name: CONCORDIUM_NODE_RPC_SERVER_ADDR
+          value: "0.0.0.0"
+        - name: CONCORDIUM_NODE_PROMETHEUS_SERVER
+          value: "1"
+        - name: CONCORDIUM_NODE_PROMETHEUS_LISTEN_ADDRESSS
+          value: "0.0.0.0"
         ports:
         - name: p2p
           containerPort: 8888
@@ -49,22 +58,29 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /mnt/data
+        - name: genesis
+          mountPath: /mnt/genesis
       {{- if .Values.nodeName }}
       - name: collector
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        command:
-        - /node-collector
-        - --collector-url=http://dashboard.mainnet.concordium.software/nodes/post
-        - --grpc-host=http://localhost:10000
-        - --node-name={{ .Values.nodeName }}
+        command: [ /node-collector ]
+        env:
+        - name: CONCORDIUM_NODE_COLLECTOR_URL
+          value: "https://dashboard.{{ include "domain" . }}/nodes/post"
+        - name: CONCORDIUM_NODE_COLLECTOR_GRPC_HOST
+          value: "http://localhost:10000"
+        - name: CONCORDIUM_NODE_COLLECTOR_NODE_NAME
+          value: "{{ .Values.nodeName }}"
+        - name: CONCORDIUM_NODE_COLLECTOR_ARTIFICIAL_START_DELAY
+          value: "120000" # 2m
       {{- end }}
-      initContainers:
-      - name: init-genesis
-        image: "{{ .Values.genesisImage.repository }}:{{ .Values.genesisImage.tag }}"
-        command: cp /genesis.dat /mnt/data/genesis.dat
-        volumeMounts:
-        - name: data
-          mountPath: /mnt/data
+      volumes:
+      - name: genesis
+        configMap:
+          name: genesis
+          items:
+          - key: "{{ .Values.network }}"
+            path: ./genesis.dat
       enableServiceLinks: false
       {{- with .Values.restartPolicy }}
       restartPolicy: {{ . }}

--- a/helm-charts/concordium-node/templates/statefulset.yaml
+++ b/helm-charts/concordium-node/templates/statefulset.yaml
@@ -30,8 +30,6 @@ spec:
           value: /mnt/data
         - name: CONCORDIUM_NODE_CONFIG_DIR
           value: /mnt/data
-        - name: CONCORDIUM_NODE_CONSENSUS_IMPORT_BLOCKS_FROM
-          value: /mnt/data/blocks.mdb
         - name: CONCORDIUM_NODE_CONSENSUS_GENESIS_DATA_FILE
           value: /mnt/genesis/genesis.dat
         - name: CONCORDIUM_NODE_CONNECTION_BOOTSTRAP_NODES

--- a/helm-charts/concordium-node/templates/tests/configmap.yaml
+++ b/helm-charts/concordium-node/templates/tests/configmap.yaml
@@ -9,7 +9,7 @@ data:
   get-consensus-status.sh: |
     #!/bin/sh
     set -eux
-    wget -O ./concordium-client https://distribution.concordium.software/tools/linux/concordium-client_1.0.1
+    wget -O ./concordium-client https://distribution.concordium.software/tools/linux/concordium-client_3.0.4-0
     chmod +x ./concordium-client
     # Ping a random replica.
     ./concordium-client --grpc-ip concordium-node.default.svc.cluster.local --grpc-port 10000 consensus status

--- a/helm-charts/concordium-node/templates/tests/configmap.yaml
+++ b/helm-charts/concordium-node/templates/tests/configmap.yaml
@@ -9,7 +9,7 @@ data:
   get-consensus-status.sh: |
     #!/bin/sh
     set -eux
-    wget -O ./concordium-client https://distribution.concordium.software/tools/linux/concordium-client_{{ .Values.concordiumClientVersion }}
+    wget -O ./concordium-client https://distribution.concordium.software/tools/linux/concordium-client_{{ .Values.test.concordiumClientVersion }}
     chmod +x ./concordium-client
     # Ping a random replica.
     ./concordium-client --grpc-ip={{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local --grpc-port=10000 consensus status

--- a/helm-charts/concordium-node/templates/tests/configmap.yaml
+++ b/helm-charts/concordium-node/templates/tests/configmap.yaml
@@ -9,7 +9,7 @@ data:
   get-consensus-status.sh: |
     #!/bin/sh
     set -eux
-    wget -O ./concordium-client https://distribution.concordium.software/tools/linux/concordium-client_3.0.4-0
+    wget -O ./concordium-client https://distribution.concordium.software/tools/linux/concordium-client_{{ .Values.concordiumClientVersion }}
     chmod +x ./concordium-client
     # Ping a random replica.
     ./concordium-client --grpc-ip={{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local --grpc-port=10000 consensus status

--- a/helm-charts/concordium-node/templates/tests/configmap.yaml
+++ b/helm-charts/concordium-node/templates/tests/configmap.yaml
@@ -12,4 +12,4 @@ data:
     wget -O ./concordium-client https://distribution.concordium.software/tools/linux/concordium-client_3.0.4-0
     chmod +x ./concordium-client
     # Ping a random replica.
-    ./concordium-client --grpc-ip concordium-node.default.svc.cluster.local --grpc-port 10000 consensus status
+    ./concordium-client --grpc-ip={{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local --grpc-port=10000 consensus status

--- a/helm-charts/concordium-node/values.yaml
+++ b/helm-charts/concordium-node/values.yaml
@@ -45,3 +45,8 @@ resources: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+# test configures test parameters.
+test:
+  # concordiumClientVersion is the version used to query the node in tests.
+  concordiumClientVersion: 3.0.4-0

--- a/helm-charts/concordium-node/values.yaml
+++ b/helm-charts/concordium-node/values.yaml
@@ -2,17 +2,23 @@
 
 # nodeName is the name of the node to be presented on the public dashboard.
 # Leave empty to disable the collector container entirely.
-nodeName: test
+nodeName: ""
+
+# domain is the domain of the network and is used to locate the bootstrapper and dashboard backend for the collector.
+# If empty, then the domain is inferred from the network name.
+domain: ""
+
+# network is the name of the network to join.
+# The chart expects to find a field with the name of the network in the configmap 'genesis'.
+# If domain is empty, then it's inferred from the network as follows:
+# If network is "mainnet", then domain is "mainnet.concordium.software".
+# Otherwise, domain is "<network>.concordium.com".
+network: testnet
 
 # image is the image repository and tag to used for the 'node' and 'collector' containers.
 image:
   repository: bisgardo/concordium-node
-  tag: "1.0.1-0_1"
-
-# genesisImage is the image repository and tag to used for the 'init-genesis` container.
-genesisImage:
-  repository: bisgardo/concordium-node-genesis
-  tag: "mainnet-0"
+  tag: "3.0.2-0_1"
 
 # service configures the service type and the ports of the individual endpoints exposed by the service.
 service:
@@ -22,10 +28,10 @@ service:
     metrics: 9090
     rpc: 10000
 
-# storage configures the class and size of the persistent volume that the database is stored in.
+# storage configures the class and size of the persistent volume in which the LMDB database is stored.
 storage:
   className: standard
-  size: 10Gi
+  size: 100Gi
 
 # The fields below are kept from the scaffolding initialized by Helm to do detailed configuration of the deployment.
 # See their use in 'templates/statefulset.yaml' and lookup the docs of the relevant fields in the official API docs


### PR DESCRIPTION
Improvements:
- Replace use of CLI args with env vars.
- Parameterize domain and network.
- Load genesis from configmap instead of init container.
- Document prerequisites.