### PR TITLE
CI: Add first step for printing input parameters

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -22,6 +22,10 @@ jobs:
   build-push:
     runs-on: ubuntu-latest
     steps:
+    - name: Inputs
+      run: |
+        echo "node_tag: ${{ env.node_tag }}"
+        echo "node_image_tag: ${{ env.node_image_tag }}"
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Log in to Docker Hub


### PR DESCRIPTION
When running a GitHub Actions workflow, the values of the input parameters are not printed as part of the job overview. Closer inspection reveals that the environment section is printed as part of the commands run in the individual steps. Still, having the inputs clearly listed in an initial step makes them much easier to find.

TODO: Put labels on images to indicate which commits they were built from (both this repo and ideally also the cloned ones).