### PR TITLE
Add ability to specify different image for collector

### DIFF
--- a/helm-charts/concordium-node/templates/statefulset.yaml
+++ b/helm-charts/concordium-node/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
       {{- end }}
       containers:
       - name: node
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.node.image }}"
         command: [ /concordium-node ]
         env:
         - name: CONCORDIUM_NODE_DATA_DIR
@@ -58,9 +58,9 @@ spec:
           mountPath: /mnt/data
         - name: genesis
           mountPath: /mnt/genesis
-      {{- if .Values.nodeName }}
+      {{- if .Values.node.name }}
       - name: collector
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.node.collectorImage | default .Values.node.image }}"
         command: [ /node-collector ]
         env:
         - name: CONCORDIUM_NODE_COLLECTOR_URL
@@ -68,9 +68,7 @@ spec:
         - name: CONCORDIUM_NODE_COLLECTOR_GRPC_HOST
           value: "http://localhost:10000"
         - name: CONCORDIUM_NODE_COLLECTOR_NODE_NAME
-          value: "{{ .Values.nodeName }}"
-        - name: CONCORDIUM_NODE_COLLECTOR_ARTIFICIAL_START_DELAY
-          value: "120000" # 2m
+          value: "{{ .Values.node.name }}"
       {{- end }}
       volumes:
       - name: genesis

--- a/helm-charts/concordium-node/values.yaml
+++ b/helm-charts/concordium-node/values.yaml
@@ -15,10 +15,14 @@ domain: ""
 # Otherwise, domain is "<network>.concordium.com".
 network: testnet
 
-# image is the image repository and tag to used for the 'node' and 'collector' containers.
-image:
-  repository: bisgardo/concordium-node
-  tag: "3.0.2-0_1"
+app:
+  node:
+    # image is the name of the image used for the 'node' container.
+    image: "bisgardo/concordium-node:3.0.2-0_1"
+  collector:
+    # image is the name of the image used for the 'collector' container.
+    # If empty, this defaults to the node image.
+    image: ""
 
 # service configures the service type and the ports of the individual endpoints exposed by the service.
 service:

--- a/helm-charts/concordium-node/values.yaml
+++ b/helm-charts/concordium-node/values.yaml
@@ -1,28 +1,25 @@
 # Default values for concordium-node.
 
-# nodeName is the name of the node to be presented on the public dashboard.
-# Leave empty to disable the collector container entirely.
-nodeName: ""
-
 # domain is the domain of the network and is used to locate the bootstrapper and dashboard backend for the collector.
-# If empty, then the domain is inferred from the network name.
+# If empty, then the value is inferred from the network field (below) as follows:
+# - If network is "mainnet", then domain is "mainnet.concordium.software".
+# - Otherwise, domain is "<network>.concordium.com".
 domain: ""
 
 # network is the name of the network to join.
 # The chart expects to find a field with the name of the network in the configmap 'genesis'.
-# If domain is empty, then it's inferred from the network as follows:
-# If network is "mainnet", then domain is "mainnet.concordium.software".
-# Otherwise, domain is "<network>.concordium.com".
+# The value of network is used to infer the domain field in case it's empty, as described above.
 network: testnet
 
-app:
-  node:
-    # image is the name of the image used for the 'node' container.
-    image: "bisgardo/concordium-node:3.0.2-0_1"
-  collector:
-    # image is the name of the image used for the 'collector' container.
-    # If empty, this defaults to the node image.
-    image: ""
+node:
+  # name is the name of the node to be presented on the public dashboard.
+  # Leaving empty will disable the collector container entirely.
+  name: ""
+  # image is the name of the image used for the 'node' container.
+  image: "bisgardo/concordium-node:3.0.2-0_1"
+  # collectorImage is the name of the image used for the 'collector' container.
+  # If empty, this defaults to the node image.
+  collectorImage: ""
 
 # service configures the service type and the ports of the individual endpoints exposed by the service.
 service:


### PR DESCRIPTION
This is required for supporting the [official images](https://hub.docker.com/u/concordium), where the different applications are built into separate images.

The values file has been restructured a little: Images are now specified in a single field instead of separating the repository from the tag.

If the collector image is unspecified it will still default to the node image.

The node name is moved into the same `node` key as the images.