### PR TITLE
Testnet: Bump active tag/image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Except for usage in FROM, these ARGs need to be redeclared in the contexts that they're used in.
 # Default values defined here will still apply if they're not overridden.
 ARG tag
-ARG ghc_version=8.10.4
+ARG ghc_version=9.0.2
 ARG rust_version=1.53.0
 ARG flatbuffers_tag=v2.0.0
 ARG extra_features='instrumentation'

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ FROM debian:${debian_base_image_tag}
 # - 'libpq5' (PostgreSQL driver): Used by Node's transaction logging feature.
 # - 'liblmdb0'(LMDB implementation): Used to persist the Node's state.
 RUN apt-get update && \
-    apt-get install -y ca-certificates libpq5 liblmdb0 && \
+    apt-get install -y ca-certificates libpq5 liblmdb0 libnuma1 && \
     rm -rf /var/lib/apt/lists/*
 
 # P2P listen port ('concordium-node').

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The currently active tag (as of 2022-06-20) is `4.1.1-1` for mainnet and `4.2.1-
 
 *Optional*
 
-The build args `ghc_version` and `rust_version` override the default values of 8.10.4 and 1.53.0, respectively.
+The build args `ghc_version` and `rust_version` override the default values of 9.0.2 and 1.53.0, respectively.
 Additionally, the build arg `extra_features` (defaults to `instrumentation`) set
 desired feature flags (`collector` is hardcoded so should not be specified).
 Note that when `instrumentation` is set,

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If a branch name is used for `<tag>` (not recommended),
 then the `--no-cache` flag should be set to prevent the Docker daemon from caching
 the cloned source code at the current commit.
 
-The currently active tag (as of 2022-06-20) is `4.1.1-1` for both mainnet and testnet.
+The currently active tag (as of 2022-06-20) is `4.1.1-1` for mainnet and `4.2.1-0` for testnet.
 
 *Optional*
 

--- a/testnet+txlog.env
+++ b/testnet+txlog.env
@@ -6,8 +6,8 @@ COMPOSE_PROFILES=prometheus,node-dashboard,txlog
 DOMAIN=testnet.concordium.com
 GENESIS_DATA_FILE=./genesis/testnet-1.dat
 OOB_CATCHUP_REFRESH_AGE_SECS=2592000 # 30d
-NODE_IMAGE=bisgardo/concordium-node:4.2.1-0_0
-NODE_DASHBOARD_IMAGE=bisgardo/concordium-node-dashboard:node-4.2.1-0_0
+NODE_IMAGE=bisgardo/concordium-node:4.2.1-0_1
+NODE_DASHBOARD_IMAGE=bisgardo/concordium-node-dashboard:node-4.2.1-0_1
 
 # Prometheus configuration.
 PROMETHEUS_IMAGE=prom/prometheus:v2.36.2

--- a/testnet+txlog.env
+++ b/testnet+txlog.env
@@ -6,8 +6,8 @@ COMPOSE_PROFILES=prometheus,node-dashboard,txlog
 DOMAIN=testnet.concordium.com
 GENESIS_DATA_FILE=./genesis/testnet-1.dat
 OOB_CATCHUP_REFRESH_AGE_SECS=2592000 # 30d
-NODE_IMAGE=bisgardo/concordium-node:4.1.1-1_0
-NODE_DASHBOARD_IMAGE=bisgardo/concordium-node-dashboard:node-4.1.1-1_0
+NODE_IMAGE=bisgardo/concordium-node:4.2.1-0_0
+NODE_DASHBOARD_IMAGE=bisgardo/concordium-node-dashboard:node-4.2.1-0_0
 
 # Prometheus configuration.
 PROMETHEUS_IMAGE=prom/prometheus:v2.36.2

--- a/testnet.env
+++ b/testnet.env
@@ -6,8 +6,8 @@ COMPOSE_PROFILES=prometheus,node-dashboard
 DOMAIN=testnet.concordium.com
 GENESIS_DATA_FILE=./genesis/testnet-1.dat
 OOB_CATCHUP_REFRESH_AGE_SECS=2592000 # 30d
-NODE_IMAGE=bisgardo/concordium-node:4.1.1-1_0
-NODE_DASHBOARD_IMAGE=bisgardo/concordium-node-dashboard:node-4.1.1-1_0
+NODE_IMAGE=bisgardo/concordium-node:4.2.1-0_0
+NODE_DASHBOARD_IMAGE=bisgardo/concordium-node-dashboard:node-4.2.1-0_0
 
 # Prometheus configuration.
 PROMETHEUS_IMAGE=prom/prometheus:v2.36.2

--- a/testnet.env
+++ b/testnet.env
@@ -6,8 +6,8 @@ COMPOSE_PROFILES=prometheus,node-dashboard
 DOMAIN=testnet.concordium.com
 GENESIS_DATA_FILE=./genesis/testnet-1.dat
 OOB_CATCHUP_REFRESH_AGE_SECS=2592000 # 30d
-NODE_IMAGE=bisgardo/concordium-node:4.2.1-0_0
-NODE_DASHBOARD_IMAGE=bisgardo/concordium-node-dashboard:node-4.2.1-0_0
+NODE_IMAGE=bisgardo/concordium-node:4.2.1-0_1
+NODE_DASHBOARD_IMAGE=bisgardo/concordium-node-dashboard:node-4.2.1-0_1
 
 # Prometheus configuration.
 PROMETHEUS_IMAGE=prom/prometheus:v2.36.2


### PR DESCRIPTION
The node now builds with GHC version 9.0.2. For some reason, this entails a run-time dependency to libnuma.