### PR TITLE
Compose: Put OOB data in dedicated volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,13 +234,11 @@ The provided `<network>.env` files set the value such that the block archive is 
 whenever the node needs to catch up more than 30 days worth of blocks.
 
 Although the block archive has no use once OOB has completed, there is no mechanism for deleting it automatically.
-It's easily done manually though:
+It's easily done manually though by just wiping the OOB volume `<oob>`:
 
 ```shell
-docker run --rm --volume=<data>:/mnt/data busybox rm /mnt/data/blocks.mdb
+docker volume rm --force <oob>
 ```
-
-where `<data>` is the name of the deployment's data volume.
 
 ### Metrics
 
@@ -262,11 +260,10 @@ The dockerfile `backup.Dockerfile` builds an image that supports that format:
 docker build -f ./backup.Dockerfile -t concordium-backup --pull .
 ```
 
-As an example, the following command archives the contents of a volume `data` (excluding any OOB file `blocks.mdb`)
-into a file `./backup/data.tar.xz` located in a bind mount:
+As an example, the following command archives the contents of a volume `data` into a file `./backup/data.tar.xz` located in a bind mount:
 
 ```shell
-docker run --rm --volume=data:/mnt/data --volume="${PWD}/backup":/mnt/backup --workdir=/mnt concordium-backup tar -Jcf ./backup/data.tar.xz --exclude=blocks.mdb ./data
+docker run --rm --volume=data:/mnt/data --volume="${PWD}/backup":/mnt/backup --workdir=/mnt concordium-backup tar -Jcf ./backup/data.tar.xz ./data
 ```
 
 Restoring the backup at `./backup/data.tar.xz` into a fresh (or properly wiped) volume `data`

--- a/docker-compose.oob.yaml
+++ b/docker-compose.oob.yaml
@@ -9,6 +9,7 @@ services:
     - OOB_CATCHUP_REFRESH_AGE_SECS
     volumes:
     - data:/mnt/data
+    - oob:/mnt/oob
     entrypoint:
     - /bin/sh
     - -xc
@@ -21,13 +22,17 @@ services:
 
       # Fetch blocks unless age is less than configured limit which defaults to "now" (i.e. never).
       [ "$${age_secs}" -lt "$${OOB_CATCHUP_REFRESH_AGE_SECS-$${now_ts}}" ] ||
-        curl -sSf https://catchup.${DOMAIN}/blocks_to_import.mdb -o /mnt/data/blocks.mdb
+        curl -sSf https://catchup.${DOMAIN}/blocks_to_import.mdb -o /mnt/oob/blocks.mdb
   node:
     environment:
-    - CONCORDIUM_NODE_CONSENSUS_IMPORT_BLOCKS_FROM=/mnt/data/blocks.mdb
+    - CONCORDIUM_NODE_CONSENSUS_IMPORT_BLOCKS_FROM=/mnt/oob/blocks.mdb
     # Defer container start until the init containers have completed successfully.
     # Note that no logs are emitted on stdout until all containers have started.
     # Also, this syntax requires Docker Compose v. 1.29+.
     depends_on:
       node_oob_catchup:
         condition: service_completed_successfully
+    volumes:
+    - oob:/mnt/oob
+volumes:
+  oob:


### PR DESCRIPTION
This separates the OOB file which gets stale immediately from the DB which stays in active use, adding confidence that the file (or the whole volume for that matter) may be wiped without unintended side effects. It also removes the need for an `--exclude` exception in the command for backing up data.