### PR TITLE
Compose: Add CCDScan to deployment as an override

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,10 @@ or the `<network>` parameter of `./run.sh`.
 See the [official documentation](https://github.com/Concordium/concordium-rosetta) of `concordium-rosetta`
 for more details about this application.
 
+## CCDScan
+
+TODO ...
+
 ## CI: Public images
 
 A GitHub Actions CI job for building and pushing the images to

--- a/docker-compose.ccdscan.yaml
+++ b/docker-compose.ccdscan.yaml
@@ -1,0 +1,45 @@
+version: "3.0"
+services:
+  # TODO Add frontend.
+  ccdscan_backend:
+    image: ${CCDSCAN_IMAGE}
+    ports:
+    - "5000:5000"
+    environment:
+    - ImportValidation__Enabled=false
+    - ConcordiumNodeGrpc__AuthenticationToken=rpcadmin
+    - ConcordiumNodeGrpc__Address=http://node:10000
+    - PostgresDatabase__ConnectionString=
+        Host=timescaledb;
+        Port=5432;
+        Database=ccscan;
+        User ID=postgres;
+        Password=password;
+        Include Error Detail=true;
+    - PostgresDatabase__ConnectionStringNodeCache=
+    - Host=timescaledb;
+        Port=5432;
+        Database=ccscan_node_cache;
+        User ID=postgres;
+        Password=password;
+        Include Error Detail=true;
+    - FeatureFlags__ConcordiumNodeImportEnabled=true
+    - FeatureFlags__MigrateDatabasesAtStartup=true
+    - NodeCollectorService__Address=https://dashboard.${DOMAIN}/nodesSummary
+    networks:
+    - concordium
+    - ccdscan
+    depends_on:
+    - timescaledb
+  ccdscan_timescaledb:
+    image: ${CCDSCAN_TIMESCALEDB_IMAGE-timescale/timescaledb:latest-pg13}
+    environment:
+    - POSTGRES_PASSWORD=password
+    networks:
+    - ccdscan
+    volumes:
+    - ccdscan:/home/postgres/pgdata/data
+volumes:
+  ccdscan:
+networks:
+  ccdscan:

--- a/docker-compose.ccdscan.yaml
+++ b/docker-compose.ccdscan.yaml
@@ -31,6 +31,7 @@ services:
     - ccdscan
     depends_on:
     - timescaledb
+  # TODO Connect to external DB by default and enable this with another override.
   ccdscan_timescaledb:
     image: ${CCDSCAN_TIMESCALEDB_IMAGE-timescale/timescaledb:latest-pg13}
     environment:

--- a/mainnet.env
+++ b/mainnet.env
@@ -23,3 +23,6 @@ TXLOG_PGDATABASE=${NETWORK}_concordium_txlog
 # Rosetta (not enabled by default).
 ROSETTA_IMAGE=concordium/rosetta:0.6.0-0
 ROSETTA_NETWORK=${NETWORK}
+
+# CCDScan.
+CCDSCAN_IMAGE=1.2.0-0

--- a/testnet.env
+++ b/testnet.env
@@ -23,3 +23,6 @@ TXLOG_PGDATABASE=${NETWORK}_concordium_txlog
 # Rosetta (not enabled by default).
 ROSETTA_IMAGE=concordium/rosetta:0.6.0-0
 ROSETTA_NETWORK=${NETWORK}
+
+# CCDScan.
+CCDSCAN_IMAGE=1.2.0-0


### PR DESCRIPTION
Adding feature `ccdscan` as an override (because it adds a new volume).

TODO:
- Add CCDScan frontend.
- Move main services to main deployment under profile. Only keep the DB in an override.