### PR TITLE
Docker: Use released binaries of protoc and CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The two applications are intended to run in separate containers instantiated fro
 The image may be build with Docker using the following command or using Docker Compose as described below:
 
 ```shell
-docker build -t concordium-node:<tag> --build-arg tag=<tag> .
+docker build -t concordium-node:<tag> --build-arg=tag=<tag> .
 ```
 
 where `<tag>` is the desired commit tag from the
@@ -112,7 +112,7 @@ A working Envoy configuration is stored in [`envoy.yaml`](./node-dashboard/envoy
 Build:
 
 ```shell
-docker build -t concordium-node-dashboard:<tag> --build-arg tag=main ./node-dashboard
+docker build -t concordium-node-dashboard:<tag> --build-arg=tag=main ./node-dashboard
 ```
 
 Run:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If a branch name is used for `<tag>` (not recommended),
 then the `--no-cache` flag should be set to prevent the Docker daemon from using a
 previously cached clone of the source code at an older version of the branch.
 
-The currently active tag (as of 2022-05-08) is `5.3.2-1` for mainnet and `5.4.2-0` for testnet.
+The currently active tag (as of 2023-06-20) is `5.4.2-0` for both mainnet and testnet.
 
 *Optional*
 

--- a/mainnet.env
+++ b/mainnet.env
@@ -8,7 +8,7 @@ COMPOSE_PROJECT_NAME=${NETWORK}
 DOMAIN=${NETWORK}.concordium.software
 
 # Node (always enabled).
-NODE_VERSION=5.3.2-1_0
+NODE_VERSION=5.4.2-0_1
 NODE_IMAGE=bisgardo/concordium-node:${NODE_VERSION}
 GENESIS_DATA_FILE=./genesis/mainnet-0.dat
 

--- a/testnet.env
+++ b/testnet.env
@@ -8,7 +8,7 @@ COMPOSE_PROJECT_NAME=${NETWORK}
 DOMAIN=${NETWORK}.concordium.com
 
 # Node (always enabled).
-NODE_VERSION=5.4.2-0_0
+NODE_VERSION=5.4.2-0_1
 NODE_IMAGE=bisgardo/concordium-node:${NODE_VERSION}
 GENESIS_DATA_FILE=./genesis/testnet-1.dat
 


### PR DESCRIPTION
This change reduces build time by downloading and installing the official binaries of `protoc` and `cmake` released by the projects' maintainers rather than building them directly from source. According to local measurements, this speeds up the complete build by 30%.

Additionally, the protobuf version is bumped from v3.15.8 to v3.20.1.

Note that the custom CMake build is used only to compile 'flatc', which is still necessary due to mismatching toolchain versions. A comment explaining this was added as well.