### PR TITLE
Docker: Bump GHC version to fix build for Node 6.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ ARG git_repo_url='https://github.com/Concordium/concordium-node.git'
 
 # Tag of node to build. The default value the oldest version of the node that the build file has been verified to work with.
 # It's intended to serve only as documentation as the user is expected to override the value.
-ARG tag=5.3.2-1
-ARG ghc_version=9.2.7
+ARG tag=6.3.0-0
+ARG ghc_version=9.6.4
 ARG rust_version=1.68.2
 ARG cmake_version=3.16.3
 ARG flatbuffers_tag=v22.12.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -111,6 +111,7 @@ RUN mkdir -p /target/bin && \
     mkdir -p /target/lib && \
     cp ./concordium-base/rust-src/target/release/*.so /target/lib/ && \
     cp ./concordium-base/smart-contracts/lib/*.so /target/lib/ && \
+    cp "$(stack --stack-yaml=./concordium-consensus/stack.yaml path --local-install-root)/lib/libconcordium-consensus.so" /target/lib/ && \
     cp "$(stack --stack-yaml=./concordium-consensus/stack.yaml path --local-install-root)/lib/x86_64-linux-ghc-${ghc_version}"/libHS*.so /target/lib/ && \
     cp "$(stack --stack-yaml=./concordium-consensus/stack.yaml path --snapshot-install-root)/lib/x86_64-linux-ghc-${ghc_version}"/libHS*.so /target/lib/ && \
     cp "$(stack --stack-yaml=./concordium-consensus/stack.yaml ghc -- --print-libdir)"/*/lib*.so* /target/lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,14 @@ ARG git_repo_url='https://github.com/Concordium/concordium-node.git'
 ARG tag=6.3.0-0
 
 # Used to provide feature flags to the build command. The feature `profiling` should not be set for reasons explained in the build image below.
-# The full set of supported feature flags may be found in https://github.com/Concordium/concordium-node/blob/main/concordium-node/Cargo.toml,
+# The full set of supported feature flags may be found at https://github.com/Concordium/concordium-node/blob/main/concordium-node/Cargo.toml,
 # but it's not well documented.
 ARG node_features=''
 
 # Versions of external build tools and base image.
 ARG ghc_version=9.6.4
 ARG rust_version=1.68.2
-ARG cmake_version=3.16.3
-# TODO: Download instead of building?
-ARG flatbuffers_tag=v23.5.26
+ARG flatbuffers_version=23.5.26
 ARG protobuf_version=25.3
 ARG debian_release='buster'
 
@@ -28,35 +26,6 @@ ARG git_repo_url
 ARG tag
 WORKDIR /source
 RUN git -c advice.detachedHead=false clone --branch="${tag}" --recurse-submodules --depth=1 "${git_repo_url}" .
-
-# Clone and compile FlatBuffers compiler 'flatc'.
-# This is necessary because the official binaries are built against a newer runtime version than the one shipped with Buster.
-FROM debian:${debian_release}-slim AS flatbuffers
-# Install build dependencies:
-# - 'curl': Used to fetch CMake binary and modules.
-# - 'git': Used to fetch FlatBuffers source.
-# - 'g++': Used to compile FlatBuffers source files.
-# - 'make': Used to orchestrate the FlatBuffers build (via CMake).
-RUN apt-get update && \
-    apt-get install -y curl git g++ make && \
-    rm -rf /var/lib/apt/lists/*
-# Download and install suitable version of CMake.
-# This is currently necessary as the version shipped with Buster's official repo (v3.13) is too old to build the latest tag (v3.16+).
-# The tool was previously built from source; see commit 7001a39 for the implementation.
-WORKDIR /tmp/cmake
-ARG cmake_version
-RUN curl -sSfL "https://github.com/Kitware/CMake/releases/download/v${cmake_version}/cmake-${cmake_version}-linux-x86_64.tar.gz" | \
-    tar -zx --strip-components=1 && \
-    mv bin/cmake /usr/local/bin/ && \
-    mv share/cmake-* /usr/local/share/
-WORKDIR /build
-ARG flatbuffers_tag
-# Clone with full history because some build step uses 'git describe' to print some version.
-# The build doesn't crash if this fails, but the full repo is only 32 MB and the logs look better without "fatal" errors in them.
-RUN git -c advice.detachedHead=false clone --branch="${flatbuffers_tag}" https://github.com/google/flatbuffers.git .
-RUN cmake -G "Unix Makefiles" . && \
-    make -j"$(nproc)" && \
-    make install
 
 # Build 'concordium-node' (and 'node-collector') in temporary image.
 FROM haskell:${ghc_version}-slim-${debian_release} AS build
@@ -94,9 +63,16 @@ RUN curl \
 # Compile consensus (Haskell and some Rust).
 RUN stack build --stack-yaml=./concordium-consensus/stack.yaml
 
-# Copy 'flatc' binary that was built in a previous step and verify that it's callable.
-COPY --from=flatbuffers /usr/local/bin/flatc /usr/local/bin/flatc
-RUN flatc --version > /dev/null
+# Download and install suitable version of the FlatBuffers compiler 'flatc' and verify that it's callable.
+# This tool was previously built from source; see commit 09f2211 for the implementation.
+ARG flatbuffers_version
+RUN curl \
+        -sSfL \
+        -o flatc.zip \
+        "https://github.com/google/flatbuffers/releases/download/v${flatbuffers_version}/Linux.flatc.binary.g++-10.zip" && \
+    unzip -qq flatc.zip flatc -d /usr/local/bin && \
+    rm flatc.zip && \
+    flatc --version > /dev/null
 
 # Compile 'concordium-node' (Rust, depends on consensus).
 # Note that feature 'profiling' implies 'static' (i.e. static linking).

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,19 @@ ARG git_repo_url='https://github.com/Concordium/concordium-node.git'
 # Tag of node to build. The default value the oldest version of the node that the build file has been verified to work with.
 # It's intended to serve only as documentation as the user is expected to override the value.
 ARG tag=6.3.0-0
+
+# Used to provide feature flags to the build command. The feature `profiling` should not be set for reasons explained in the build image below.
+# The full set of supported feature flags may be found in https://github.com/Concordium/concordium-node/blob/main/concordium-node/Cargo.toml,
+# but it's not well documented.
+ARG node_features=''
+
+# Versions of external build tools and base image.
 ARG ghc_version=9.6.4
 ARG rust_version=1.68.2
 ARG cmake_version=3.16.3
-ARG flatbuffers_tag=v22.12.6
-ARG protobuf_version=3.20.1
-ARG extra_features=''
+# TODO: Download instead of building?
+ARG flatbuffers_tag=v23.5.26
+ARG protobuf_version=25.3
 ARG debian_release='buster'
 
 # Clone sources.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If a branch name is used for `<tag>` (not recommended),
 then the `--no-cache` flag should be set to prevent the Docker daemon from using a
 previously cached clone of the source code at an older version of the branch.
 
-The currently active tag (as of 2023-12-06) is `6.2.3-0` for both Mainnet and Testnet.
+The currently active tag (as of 2024-02-20) is `6.2.3-0` for Mainnet and `6.3.0-0` for Testnet.
 
 *Optional*
 

--- a/README.md
+++ b/README.md
@@ -76,13 +76,9 @@ The currently active tag (as of 2023-12-06) is `6.2.3-0` for both Mainnet and Te
 
 *Optional*
 
-The build args `ghc_version` and `rust_version` override the default values of 9.2.7 and 1.68.2, respectively.
-Additionally, the build arg `node_features` may be used to provide feature flags to the build command.
-The feature `profiling` should not be set for reasons explained in the dockerfile.
-
-The full set of supported feature flags may be found in
-[`Cargo.toml`](https://github.com/Concordium/concordium-node/blob/main/concordium-node/Cargo.toml),
-but it's not well documented.
+The versions of external tools used in the build are defined as the default values of build arguments.
+This is mostly done to keep them in one place as a set of constants, but also means that they can be overriden at build time.
+See the top of the dockerfile for the available set of args.
 
 ### `concordium-node-genesis`
 

--- a/network-dashboard/Dockerfile
+++ b/network-dashboard/Dockerfile
@@ -23,5 +23,6 @@ RUN npm ci
 ARG min_version_included_in_stats
 RUN MIN_VERSION_INCLUDED_IN_STATS=${min_version_included_in_stats} npm run build
 
+# Copy build target to result image.
 FROM nginx:stable-alpine
 COPY --from=build /build/dist /usr/share/nginx/html

--- a/testnet.env
+++ b/testnet.env
@@ -8,7 +8,7 @@ COMPOSE_PROJECT_NAME=${NETWORK}
 DOMAIN=${NETWORK}.concordium.com
 
 # Node (always enabled).
-NODE_VERSION=6.2.3-0_2
+NODE_VERSION=6.3.0-0_1
 NODE_IMAGE=bisgardo/concordium-node:${NODE_VERSION}
 GENESIS_DATA_FILE=./genesis/testnet-1.dat
 


### PR DESCRIPTION
The Node has been bumped from using Stackage LTS-20.16 (GHC 9.2.7) to LTS-22.9 (GHC 0.6.4). This requires us to bump the Haskell build image accordingly to fix the build.

The default value of the 'tag' describes (as documented) the oldest version of the node that the build file has been verified to work with and has been bumped accordingly.

For historic reference, the legacy branch 'next-flatc' was merged into the branch. It's actual changes are no longer relevant and therefore weren't included (by using merge strategy 'ours').