### PR TITLE
Update for Node tag 8.0.3-1

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -38,4 +38,4 @@ jobs:
         # Define variables that are actually used in the build and perform that build/push.
         export NODE_TAG="${{ env.node_tag }}"
         export NODE_IMAGE="${{ env.node_image_repo }}:${{ env.node_image_tag }}"
-        NODE_NAME= docker compose build && docker-compose push
+        NODE_NAME= docker compose build && docker compose push

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ ARG node_features=''
 # Versions of external build tools and base image.
 ARG ghc_version=9.6.6
 ARG rust_version=1.82.0
-ARG flatbuffers_version=23.5.26
-ARG protobuf_version=25.3
+ARG flatbuffers_version=25.2.10
+ARG protobuf_version=31.0
 ARG debian_release='bullseye'
 
 # Clone sources.
@@ -70,7 +70,7 @@ ARG flatbuffers_version
 RUN curl \
         -sSfL \
         -o flatc.zip \
-        "https://github.com/google/flatbuffers/releases/download/v${flatbuffers_version}/Linux.flatc.binary.g++-10.zip" && \
+        "https://github.com/google/flatbuffers/releases/download/v${flatbuffers_version}/Linux.flatc.binary.g++-13.zip" && \
     unzip -qq flatc.zip flatc -d /usr/local/bin && \
     rm flatc.zip && \
     flatc --version > /dev/null

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ ARG node_features=''
 # Versions of external build tools and base image.
 ARG ghc_version=9.6.6
 ARG rust_version=1.82.0
-ARG flatbuffers_cmake_version=3.16.3
-ARG flatbuffers_tag=v22.12.06 # keep in sync with 'flatbuffers' dependency in https://github.com/Concordium/concordium-node/blob/main/concordium-node/Cargo.toml#L52
+# To be kept in sync with 'flatbuffers' dependency in https://github.com/Concordium/concordium-node/blob/main/concordium-node/Cargo.toml#L52.
+ARG flatbuffers_tag=v22.12.06
 ARG protobuf_version=31.0
 ARG debian_release='bullseye'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,22 +33,13 @@ RUN git -c advice.detachedHead=false clone --branch="${tag}" --recurse-submodule
 # This is necessary because the official binaries are built against a version of glibc that isn't compatible with Bullseye.
 FROM debian:${debian_release}-slim AS flatbuffers
 # Install build dependencies:
-# - 'curl': Used to fetch CMake binary and modules.
+# - 'cmake': Used to fetch CMake binary and modules.
 # - 'git': Used to fetch FlatBuffers source.
 # - 'g++': Used to compile FlatBuffers source files.
 # - 'make': Used to orchestrate the FlatBuffers build (via CMake).
 RUN apt-get update && \
-    apt-get install -y curl git g++ make && \
+    apt-get install -y cmake git g++ make && \
     rm -rf /var/lib/apt/lists/*
-# Download and install suitable version of CMake.
-# This is currently necessary as the version shipped with Buster's official repo (v3.13) is too old to build the latest tag (v3.16+).
-# The tool was previously built from source; see commit b6477ee for the change.
-WORKDIR /tmp/cmake
-ARG flatbuffers_cmake_version
-RUN curl -sSfL "https://github.com/Kitware/CMake/releases/download/v${flatbuffers_cmake_version}/cmake-${flatbuffers_cmake_version}-linux-x86_64.tar.gz" | \
-    tar -zx --strip-components=1 && \
-    mv bin/cmake /usr/local/bin/ && \
-    mv share/cmake-* /usr/local/share/
 WORKDIR /build
 ARG flatbuffers_tag
 # Clone with full history because some build step uses 'git describe' to print some version.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,10 @@
 # Repository holding the source code for the Node.
 ARG git_repo_url='https://github.com/Concordium/concordium-node.git'
 
-# Tag of node to build. The default value the oldest version of the node that the build file has been verified to work with.
+# Tag of node to build. The default value the oldest version of the node that the build file has been verified to work with
+# (is updated if we need to bump compiler the default compiler versions specified below or update the script in some other way).
 # It's intended to serve only as documentation as the user is expected to override the value.
-ARG tag=6.3.0-0
+ARG tag=8.0.3-1
 
 # Used to provide feature flags to the build command. The feature `profiling` should not be set for reasons explained in the build image below.
 # The full set of supported feature flags may be found at https://github.com/Concordium/concordium-node/blob/main/concordium-node/Cargo.toml,
@@ -14,11 +15,11 @@ ARG tag=6.3.0-0
 ARG node_features=''
 
 # Versions of external build tools and base image.
-ARG ghc_version=9.6.4
-ARG rust_version=1.68.2
+ARG ghc_version=9.6.6
+ARG rust_version=1.82.0
 ARG flatbuffers_version=23.5.26
 ARG protobuf_version=25.3
-ARG debian_release='buster'
+ARG debian_release='bullseye'
 
 # Clone sources.
 FROM alpine/git:latest AS source

--- a/README.md
+++ b/README.md
@@ -258,8 +258,7 @@ Database credentials etc. are configured with the following variables:
   This value of this variable only matters when catching up a large number of blocks -
   setting it to 1 is fine during normal operation.
 
-The variables may be passed to the `docker compose` command above or persisted in a `.env` file as described below
-(see [`testnet.env`](./testnet.env) and [`mainnet.env`](./mainnet.env);
+The variables may be passed to the `docker compose` command above or persisted in an env file as [described below](#ci-public-images).
 note that `TXLOG_PGPASSWORD` still has to be passed explicitly).
 
 See [`postgresql.md`](./postgresql.md) for instructions on how to set up a local database.
@@ -310,6 +309,8 @@ docker compose pull # prevent 'up' from building instead of pulling
 docker compose --project-name=mainnet up --profile=prometheus --no-build
 ```
 
+*TODO: Make the following its own (sub)section that explains using env files and run.sh in general. Probably belong under the section about building and running with Compose. Remember to update references (to this section) appropriately.*
+
 The convenience script [`run.sh`](./run.sh) expects to find a file `./<network>.env`
 ([`mainnet.env`](./mainnet.env) and [`testnet.env`](./testnet.env) being provided with the repo)
 from which it loads the deployment parameters and network-specific values:
@@ -344,7 +345,7 @@ To instead enable [transaction logging](#transaction-logging), append `+txlog` a
 TXLOG_PGPASSWORD=<database-password> NODE_NAME=my_node ./run.sh <network> +txlog
 ```
 
-The .env files reference the most recently published images,
+The env files reference the most recently published images,
 where the version is compatible with the "currently active" tag of the corresponding network
 (as of the time the image was built).
 The tag of a given image mathes the tag of the git commit that Concordium Node was built from

--- a/README.md
+++ b/README.md
@@ -44,13 +44,9 @@ NODE_NAME=<node-name> ./run.sh <network> +prometheus +txlog
 
 ## Build
 
-By default, the builds run in images based on Debian Buster (10).
-The build arg `debian_release` may be used to select another Debian release.
-As of 2022-09-08, no other values besides the default one are supported
-due to the project's dependency on the [Haskell toolchain](https://hub.docker.com/_/haskell):
-
-> Note: Currently stable Debian is version 11 bullseye, however it is not yet supported by Haskell tooling.
-> Until that time the default will remain Debian 10 buster. We have dropped support for Debian 9 stretch.
+By default, the builds run in images based on Debian Bullseye (11).
+The build arg `debian_release` may be used to select another Debian release
+(though historically, the official Haskell image don't seem to support multiple Debian versions per GHC version).
 
 ### `concordium-node`
 
@@ -71,8 +67,6 @@ The tag is also used for the resulting Docker image.
 If a branch name is used for `<tag>` (not recommended),
 then the `--no-cache` flag should be set to prevent the Docker daemon from using a
 previously cached clone of the source code at an older version of the branch.
-
-The currently active tag (as of 2024-02-29) is `6.3.0-0` for both Mainnet and Testnet.
 
 *Optional*
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ NODE_NAME=<node-name> ./run.sh <network> +prometheus +txlog
 ## Build
 
 By default, the builds run in images based on Debian Bullseye (11).
-The build arg `debian_release` may be used to select another Debian release
-(though historically, the official Haskell image don't seem to support more than one Debian version for any given GHC version).
+The build arg `debian_release` may be used to select another Debian release,
+though no other than the default value should be expected to work.
 
 ### `concordium-node`
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ dynamically linked node for the [Concordium](https://concordium.com) blockchain.
 
 ## Quickstart
 
-Start a Concordium node deployment with node name `<node-name>`
-using Docker Compose with publicly available images:
+Start a Concordium Node deployment with name `<node-name>`
+using Docker Compose with [pre-built images](#ci-public-images):
 
 *Testnet*
 
@@ -46,7 +46,7 @@ NODE_NAME=<node-name> ./run.sh <network> +prometheus +txlog
 
 By default, the builds run in images based on Debian Bullseye (11).
 The build arg `debian_release` may be used to select another Debian release
-(though historically, the official Haskell image don't seem to support multiple Debian versions per GHC version).
+(though historically, the official Haskell image don't seem to support more than one Debian version for any given GHC version).
 
 ### `concordium-node`
 
@@ -67,6 +67,13 @@ The tag is also used for the resulting Docker image.
 If a branch name is used for `<tag>` (not recommended),
 then the `--no-cache` flag should be set to prevent the Docker daemon from using a
 previously cached clone of the source code at an older version of the branch.
+
+The latest tag may be found in the [official repository](https://github.com/Concordium/concordium-node/tags).
+However, the tags don't always match the currently deployed software versions on both networks.
+
+You may also check the tags of the [public images](#ci-public-images) (the part before `_`)
+to see what Concordium Node tag was used in the latest build (and which networks' .env files have been updated to use it).
+However, this repo not being updated regularly, so this information is prone to being outdated.
 
 *Optional*
 
@@ -303,13 +310,16 @@ docker compose pull # prevent 'up' from building instead of pulling
 docker compose --project-name=mainnet up --profile=prometheus --no-build
 ```
 
-The convenience script `run.sh` loads the parameters from a `<network>.env` file:
+The convenience script [`run.sh`](./run.sh) expects to find a file `./<network>.env`
+([`mainnet.env`](./mainnet.env) and [`testnet.env`](./testnet.env) being provided with the repo)
+from which it loads the deployment parameters and network-specific values:
 
 ```shell
 NODE_NAME=my_node ./run.sh <network> [+<feature>...]
 ```
 
-where `<feature>` is a Compose profile to be enabled and/or an override to be applied.
+where `<feature>` is a Compose profile to be enabled and/or an override to be applied ([list](#additional-features)).
+
 An override `<feature>` is a file `docker-compose.<feature>.yaml` which - if it exists - get merged
 onto the "base" `docker-compose.yaml` file.
 Multiple profiles/overrides may be enabled by appending a `+` argument for each of them.
@@ -334,11 +344,18 @@ To instead enable [transaction logging](#transaction-logging), append `+txlog` a
 TXLOG_PGPASSWORD=<database-password> NODE_NAME=my_node ./run.sh <network> +txlog
 ```
 
-Working environment files that reference the most recent public images
-are provided for Testnet and Mainnet.
+The .env files reference the most recently published images,
+where the version is compatible with the "currently active" tag of the corresponding network
+(as of the time the image was built).
+The tag of a given image mathes the tag of the git commit that Concordium Node was built from
+followed by an additional "build version" component (the part after `_`)
+The build version starts at 0 for any given Node tag and is bumped whenever a new build is pushed for that same tag
+(for example when building with an updated compiler).
+
+### Disclaimer
 
 Feel free to use these images for testing and experimentation,
-but never trust random internet strangers' binaries with anything secret or valuable.
+but never trust random internet strangers' pre-built binaries with anything secret or valuable.
 
 Instead, use the
 [officially released](https://developer.concordium.software/en/mainnet/net/guides/run-node-ubuntu.html)

--- a/mainnet.env
+++ b/mainnet.env
@@ -1,3 +1,5 @@
+# Default variable substitutions for running a Mainnet node with the Docker Compose files in this repo (using pre-built images).
+
 # Network to deploy in.
 # Note that the expansions below will use the value defined here, even if it's overridden from the outside.
 # Expansions in the Compose file will use the overridden value.
@@ -8,7 +10,7 @@ COMPOSE_PROJECT_NAME=${NETWORK}
 DOMAIN=${NETWORK}.concordium.software
 
 # Node (always enabled).
-NODE_VERSION=6.3.0-0_1
+NODE_VERSION=8.0.3-1_0
 NODE_IMAGE=bisgardo/concordium-node:${NODE_VERSION}
 GENESIS_DATA_FILE=./genesis/mainnet-0.dat
 

--- a/testnet.env
+++ b/testnet.env
@@ -1,3 +1,5 @@
+# Default variable substitutions for running a Testnet node with the Docker Compose files in this repo (using pre-built images).
+
 # Network to deploy in.
 # Note that the expansions below will use the value defined here, even if it's overridden from the outside.
 # Expansions in the Compose file will use the overridden value.
@@ -8,7 +10,7 @@ COMPOSE_PROJECT_NAME=${NETWORK}
 DOMAIN=${NETWORK}.concordium.com
 
 # Node (always enabled).
-NODE_VERSION=6.3.0-0_1
+NODE_VERSION=8.0.3-1_0
 NODE_IMAGE=bisgardo/concordium-node:${NODE_VERSION}
 GENESIS_DATA_FILE=./genesis/testnet-1.dat
 


### PR DESCRIPTION
This required a bump to GHC (and thus Debian base) and Rust versions in the Dockerfile. The FlatBuffers build dependency was downgraded to match runtime dependency (which required building it from source again) and protoc was upgraded to the latest version.

The docs are updated appropriately. In particular, the inclusion of the currently active tag is removed from the README; it's not useful there with the repo no longer being updated regularly.